### PR TITLE
Add note for CPU support in docs - Apple Sillicon compatibility

### DIFF
--- a/guides/cli/detailed-steps/part-7.-create-your-deployment.md
+++ b/guides/cli/detailed-steps/part-7.-create-your-deployment.md
@@ -4,6 +4,8 @@
 
 Only x86\_64 processors are officially supported for Akash deployments.  This may change in the future and when ARM processors are supported it will be announced and documented.
 
+You can try building your docker image by [specifying the target platform as linux/amd64](https://stackoverflow.com/a/69119815/8215759) if you are on a mac with Apple Sillicon.
+
 ## Akash Deployment
 
 To deploy on Akash, run:

--- a/guides/deploy/akashlytics-deploy-installation.md
+++ b/guides/deploy/akashlytics-deploy-installation.md
@@ -10,6 +10,8 @@ Follow our [Keplr Wallet](../../token/keplr.md) guide to create your first walle
 
 Only x86\_64 processors are officially supported for Akash deployments.  This may change in the future and when ARM processors are supported it will be announced and documented.
 
+You can try building your docker image by [specifying the target platform as linux/amd64](https://stackoverflow.com/a/69119815/8215759) if you are on a mac with Apple Sillicon.
+
 ## **Akashlytics Deploy Installation**
 
 ### **Software Access and Download Instructions**

--- a/providers/build-a-cloud-provider/akash-cloud-provider-build-with-helm-charts/step-1-prerequisites-of-an-akash-provider.md
+++ b/providers/build-a-cloud-provider/akash-cloud-provider-build-with-helm-charts/step-1-prerequisites-of-an-akash-provider.md
@@ -24,6 +24,8 @@ We have recently released documentation guiding thru the process of building a [
 
 Only x86\_64 processors are officially supported by Akash for provider Kubernetes nodes at this time.  This may change in the future and when ARM processors are supported it will be announced and documented.
 
+You can try building your docker image by [specifying the target platform as linux/amd64](https://stackoverflow.com/a/69119815/8215759) if you are on a mac with Apple Sillicon.
+
 ## Custom Kubernetes Cluster Settings
 
 Akash Providers are deployed in many environments and we will make additions to these sections as when nuances are discovered.


### PR DESCRIPTION
In the documentation it is clearly stated that [only x86_64 processors are supported for Akash deployments](https://docs.akash.network/guides/deploy/akashlytics-deploy-installation#cpu-support)

But

From a mac with m1 processor I was able to run my deploys to akash network indicating at the moment of building the docker image that the [target platform is linux/amd64.](https://stackoverflow.com/a/69119815/8215759)

---

without specifying that the target platform is linux/amd64 my images did not work

[<img width="782" alt="Screen Shot 2022-07-18 at 04 08 28" src="https://user-images.githubusercontent.com/30802967/179460481-0c49f4c9-9b9b-4822-be63-1f2d52891916.png">](https://hub.docker.com/layers/254934625/sturmenta/validate-purchase-ios/0.0.1/images/sha256-296f65a6309f559baf9320a4107a92428a4b884ed388e7d85908a61b9e3fcde3?context=repo)

after specifying this my docker images work on akash network

[<img width="766" alt="Screen Shot 2022-07-18 at 04 08 44" src="https://user-images.githubusercontent.com/30802967/179460830-e0790d83-10dc-4325-a000-20ed6f4dc13c.png">](https://hub.docker.com/layers/254983102/sturmenta/validate-purchase-ios/0.0.4/images/sha256-228fc2aad1f458a5ec6041417dbc8b2926d4cd3559782d09df9f3950948acd1a?context=repo)