### PR TITLE
bump ingress-nginx controller to 4.7.1 to tackle CVE-2023-2650

### DIFF
--- a/other-resources/experimental/akash-provider-streamlined-build-with-rancher-k3s/step-8-ingress-controller-install.md
+++ b/other-resources/experimental/akash-provider-streamlined-build-with-rancher-k3s/step-8-ingress-controller-install.md
@@ -33,7 +33,7 @@ tcp:
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 
 helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
-  --version 4.6.0 \
+  --version 4.7.1 \
   --namespace ingress-nginx --create-namespace \
   -f ingress-nginx-custom.yaml
 ```

--- a/providers/build-a-cloud-provider/akash-cloud-provider-build-with-helm-charts/step-8-ingress-controller-install.md
+++ b/providers/build-a-cloud-provider/akash-cloud-provider-build-with-helm-charts/step-8-ingress-controller-install.md
@@ -74,7 +74,7 @@ EOF
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 
 helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
-  --version 4.6.0 \
+  --version 4.7.1 \
   --namespace ingress-nginx --create-namespace \
   -f ingress-nginx-custom.yaml
 ```

--- a/testnet/provider-build-with-gpu/step-8-ingress-controller-install.md
+++ b/testnet/provider-build-with-gpu/step-8-ingress-controller-install.md
@@ -33,7 +33,7 @@ tcp:
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 
 helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
-  --version 4.6.0 \
+  --version 4.7.1 \
   --namespace ingress-nginx --create-namespace \
   -f ingress-nginx-custom.yaml
 ```


### PR DESCRIPTION
This is mainly to tackle `CVE-2023-2650` (`possible DoS translating ASN.1 object identifiers`) - https://nvd.nist.gov/vuln/detail/CVE-2023-2650

This upgrade delivers openssl-3.1.1-r1 package into the alpine-based image which is not vulnerable to CVE-2023-2650 - https://security.alpinelinux.org/vuln/CVE-2023-2650