### PR TITLE
fix nvidia-container-runtime path

### DIFF
--- a/other-resources/archived-resources/provider-build-with-gpu/nvidia-runtime-configuration.md
+++ b/other-resources/archived-resources/provider-build-with-gpu/nvidia-runtime-configuration.md
@@ -31,7 +31,7 @@ containerd_additional_runtimes:
     engine: ""
     root: ""
     options:
-      BinaryName: '"/usr/bin/nvidia-container-runtime"'
+      BinaryName: '/usr/bin/nvidia-container-runtime'
 EOF
 ```
 

--- a/other-resources/experimental/build-a-cloud-provider/gpu-resource-enablement-optional-step/gpu-provider-configuration.md
+++ b/other-resources/experimental/build-a-cloud-provider/gpu-resource-enablement-optional-step/gpu-provider-configuration.md
@@ -126,7 +126,7 @@ containerd_additional_runtimes:
     engine: ""
     root: ""
     options:
-      BinaryName: '"/usr/bin/nvidia-container-runtime"'
+      BinaryName: '/usr/bin/nvidia-container-runtime'
 EOF
 ```
 

--- a/providers/build-a-cloud-provider/gpu-resource-enablement-optional-step/gpu-provider-configuration.md
+++ b/providers/build-a-cloud-provider/gpu-resource-enablement-optional-step/gpu-provider-configuration.md
@@ -127,7 +127,7 @@ containerd_additional_runtimes:
     engine: ""
     root: ""
     options:
-      BinaryName: '"/usr/bin/nvidia-container-runtime"'
+      BinaryName: '/usr/bin/nvidia-container-runtime'
 EOF
 ```
 

--- a/providers/build-a-cloud-provider/provider-build-with-gpu/nvidia-runtime-configuration.md
+++ b/providers/build-a-cloud-provider/provider-build-with-gpu/nvidia-runtime-configuration.md
@@ -31,7 +31,7 @@ containerd_additional_runtimes:
     engine: ""
     root: ""
     options:
-      BinaryName: '"/usr/bin/nvidia-container-runtime"'
+      BinaryName: '/usr/bin/nvidia-container-runtime'
 EOF
 ```
 


### PR DESCRIPTION
fixed since kubespray v2.24.0

Thanks to peper1415 on Discord (PePeR) for notifying.